### PR TITLE
updated internal logging to include status for responses

### DIFF
--- a/src/MessageHandlers/TelemetryMetricHandler.cs
+++ b/src/MessageHandlers/TelemetryMetricHandler.cs
@@ -25,7 +25,7 @@ public partial class MessageHandler<T> {
 
             returnResponse = output_response;
 
-            _logger.LogDebug("Sending response type '{messageType}' to '{appId}'  (trackingId: '{trackingId}' / correlationId: '{correlationId}')", returnResponse.GetType().Name, fullMessage.SourceAppId, returnResponse.ResponseHeader.TrackingId, returnResponse.ResponseHeader.CorrelationId);
+            _logger.LogDebug("Sending response type '{messageType}' to '{appId}'  (trackingId: '{trackingId}' / correlationId: '{correlationId}' / status: '{status}')", returnResponse.GetType().Name, fullMessage.SourceAppId, returnResponse.ResponseHeader.TrackingId, returnResponse.ResponseHeader.CorrelationId, returnResponse.ResponseHeader.Status);
 
             // Route the response back to the calling user
             _client.DirectToApp(appId: fullMessage.SourceAppId, message: returnResponse);
@@ -75,7 +75,7 @@ public partial class MessageHandler<T> {
             returnResponse.ResponseHeader.Status = MessageFormats.Common.StatusCodes.Successful;
 
             // Log the sending of the response
-            _logger.LogDebug("Sending response type '{messageType}' to '{appId}'  (trackingId: '{trackingId}' / correlationId: '{correlationId}')", returnResponse.GetType().Name, fullMessage.SourceAppId, returnResponse.ResponseHeader.TrackingId, returnResponse.ResponseHeader.CorrelationId);
+            _logger.LogDebug("Sending response type '{messageType}' to '{appId}'  (trackingId: '{trackingId}' / correlationId: '{correlationId}' / status: '{status}')", returnResponse.GetType().Name, fullMessage.SourceAppId, returnResponse.ResponseHeader.TrackingId, returnResponse.ResponseHeader.CorrelationId, returnResponse.ResponseHeader.Status);
 
             // Send the response directly to the app
             _client.DirectToApp(appId: fullMessage.SourceAppId, message: returnResponse);

--- a/test/debugClient/Services/MessageHandler.cs
+++ b/test/debugClient/Services/MessageHandler.cs
@@ -27,7 +27,7 @@ public class MessageHandler<T> : Microsoft.Azure.SpaceFx.Core.IMessageHandler<T>
 
     public void LogMessageResponseHandler(LogMessageResponse response) {
         _logger.LogInformation($"LogMessageResponse: {response.ResponseHeader.Status}. TrackingID: {response.ResponseHeader.TrackingId}");
-    }
+    
     public void PluginConfigurationResponseHandler(PluginConfigurationResponse response) {
         _logger.LogInformation($"PluginConfigurationResponse: {response.ResponseHeader.Status}. TrackingID: {response.ResponseHeader.TrackingId}");
     }


### PR DESCRIPTION
<img width="1324" alt="image" src="https://github.com/user-attachments/assets/249c10d1-658a-4200-8a2b-dfef73beb89f">
